### PR TITLE
srt_generator: Strip whitespace from <p>-Elements.

### DIFF
--- a/ttmltosrt/ttmltosrt.py
+++ b/ttmltosrt/ttmltosrt.py
@@ -29,7 +29,7 @@ def srt_generator(ttml):
             n=caption_number,
             begin=format_timedelta(begin),
             end=format_timedelta(end),
-            content=caption.get_text(separator='\n')
+            content=caption.get_text(separator='\n', strip=True)
         )
 
 


### PR DESCRIPTION
Fixes a bug where subtitles won't show in mpv / ffplay (and probably
mplayer?) when subtitle text has too much whitespace.

To be more specific, the extra newline following the timestamp is the
problem.

Thanks.

**sample.xml**
```xml
<tt xmlns="http://www.w3.org/2006/04/ttaf1">
  <body>
    <div xml:lang="English">
	<p begin="00:00:00.100" end="00:00:01.000">
	That's a single-line example?
	</p>
	<p begin="00:00:01.100" end="00:00:02.000">
	And here is something with<br />
	a linebreak in it.
	</p>
	<p begin="00:00:02.100" end="00:00:03.000">
	Another single line
	</p>
	<p begin="00:00:03.100" end="00:00:04.000">
	Ok, let's break<br />
	the line again.
	</p>
	<p begin="00:00:04.100" end="00:00:05.000">
	The last text with a line-break<br />
	Hello World
	</p>
    </div>
  </body>
</tt>
```

**old output**
```
1
00:00:00,100 --> 00:00:01,000

	That's a single-line example?
	

2
00:00:01,100 --> 00:00:02,000

	And here is something with

	a linebreak in it.
	

3
00:00:02,100 --> 00:00:03,000

	Another single line
	

4
00:00:03,100 --> 00:00:04,000

	Ok, let's break

	the line again.
	

5
00:00:04,100 --> 00:00:05,000

	The last text with a line-break

	Hello World
	

```

**new output**
```
1
00:00:00,100 --> 00:00:01,000
That's a single-line example?

2
00:00:01,100 --> 00:00:02,000
And here is something with
a linebreak in it.

3
00:00:02,100 --> 00:00:03,000
Another single line

4
00:00:03,100 --> 00:00:04,000
Ok, let's break
the line again.

5
00:00:04,100 --> 00:00:05,000
The last text with a line-break
Hello World

```